### PR TITLE
rebasing to Alpine 3.9 and removing broken internationalization from build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:3.8
+FROM lsiobase/alpine:3.9
 
 # set version label
 ARG BUILD_DATE
@@ -89,6 +89,8 @@ RUN \
 	-DCUSTOM_DOCDIR="/usr/share/doc/minetest" \
 	-DCUSTOM_SHAREDIR="/usr/share/minetest" \
 	-DENABLE_CURL=1 \
+	-DENABLE_FREETYPE=1 \
+	-DENABLE_GETTEXT=0 \
 	-DENABLE_LEVELDB=1 \
 	-DENABLE_LUAJIT=1 \
 	-DENABLE_REDIS=1 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine.arm64:3.8
+FROM lsiobase/alpine.arm64:3.9
 
 # Add qemu to build on x86_64 systems
 COPY qemu-aarch64-static /usr/bin
@@ -92,6 +92,8 @@ RUN \
 	-DCUSTOM_DOCDIR="/usr/share/doc/minetest" \
 	-DCUSTOM_SHAREDIR="/usr/share/minetest" \
 	-DENABLE_CURL=1 \
+	-DENABLE_FREETYPE=1 \
+	-DENABLE_GETTEXT=0 \
 	-DENABLE_LEVELDB=1 \
 	-DENABLE_LUAJIT=1 \
 	-DENABLE_REDIS=1 \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine.armhf:3.8
+FROM lsiobase/alpine.armhf:3.9
 
 # Add qemu to build on x86_64 systems
 COPY qemu-arm-static /usr/bin
@@ -92,6 +92,8 @@ RUN \
 	-DCUSTOM_DOCDIR="/usr/share/doc/minetest" \
 	-DCUSTOM_SHAREDIR="/usr/share/minetest" \
 	-DENABLE_CURL=1 \
+	-DENABLE_FREETYPE=1 \
+	-DENABLE_GETTEXT=0 \
 	-DENABLE_LEVELDB=1 \
 	-DENABLE_LUAJIT=1 \
 	-DENABLE_REDIS=1 \

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Below are the instructions for updating containers:
 
 ## Versions
 
+* **04.03.19:** - Rebase to alpine 3.9 to compile 5.0.0 minetest with new build args.
 * **14.01.19:** - Add pipeline logic and multi arch.
 * **08.08.18:** - Rebase to alpine 3.8, build from latest release tag instead of master.
 * **03.01.18:** - Deprecate cpu_core routine lack of scaling.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,6 +51,7 @@ app_setup_block: |
   https://hub.docker.com/r/linuxserver/{{ project_name }}/tags
 # changelog
 changelogs:
+  - { date: "04.03.19:", desc: "Rebase to alpine 3.9 to compile 5.0.0 minetest with new build args." }
   - { date: "14.01.19:", desc: "Add pipeline logic and multi arch." }
   - { date: "08.08.18:", desc: "Rebase to alpine 3.8, build from latest release tag instead of master." }
   - { date: "03.01.18:", desc: "Deprecate cpu_core routine lack of scaling." }


### PR DESCRIPTION
To get 5.0.0 version built. 

I have no way to test this output, we might need to reach out to the community on this one. 