### PR TITLE
Need literal expansion on CLI variable to support multiple args

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **12.07.19:** - Bugfix to support multiple CLI variables.
 * **28.06.19:** - Rebasing to alpine 3.10.
 * **03.06.19:** - Adding custom cli vars to options.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -49,6 +49,7 @@ app_setup_block: |
   https://hub.docker.com/r/linuxserver/{{ project_name }}/tags
 # changelog
 changelogs:
+  - { date: "12.07.19:", desc: "Bugfix to support multiple CLI variables." }
   - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "03.06.19:", desc: "Adding custom cli vars to options." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }

--- a/root/etc/services.d/minetest/run
+++ b/root/etc/services.d/minetest/run
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv bash
 
 exec \
-	s6-setuidgid abc minetestserver "${CLI_ARGS}" \
+	s6-setuidgid abc minetestserver ${CLI_ARGS} \
 	--config /config/.minetest/main-config/minetest.conf --port 30000


### PR DESCRIPTION
https://github.com/linuxserver/docker-minetest/issues/26

Without this the string is quoted when the command is run. 