### PR TITLE
Buildfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN \
   cd /tmp/spatialindex && \
   cmake . \
     -DCMAKE_INSTALL_PREFIX=/usr && \
-  make -j 2 && \
+  make -j 4 && \
   make install && \
   echo "**** compile irrlicht ****" && \
   mkdir -p /tmp/irrlicht && \
@@ -80,7 +80,7 @@ RUN \
     /tmp/irrlicht --strip-components=1 && \
   cd /tmp/irrlicht && \
   cmake . && \
-  make -j 2 && \
+  make -j 4 && \
   make install && \
   echo "**** compile minetestserver ****" && \
   if [ -z ${MINETEST_RELEASE+x} ]; then \
@@ -113,12 +113,12 @@ RUN \
     -DENABLE_SOUND=0 \
     -DENABLE_SYSTEM_GMP=1 \
     -DRUN_IN_PLACE=0 && \
-  make -j 2 && \
+  make -j 4 && \
   make install && \
   echo "**** copy games to temporary folder ****" && \
   mkdir -p \
     /defaults/games && \
-  cp -pr  /usr/share/minetest/games/* /defaults/games/ && \
+  cp -pr  /tmp/minetest/games/* /defaults/games/ && \
   echo "**** split after 3rd dot if it exists in minetest tag variable ****" && \
   echo "**** so we fetch game version x.x.x etc ****" && \
   if [ $(echo "$MINETEST_RELEASE" | tr -cd '.' | wc -c) = 3 ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -68,7 +68,7 @@ RUN \
   cd /tmp/spatialindex && \
   cmake . \
     -DCMAKE_INSTALL_PREFIX=/usr && \
-  make -j 2 && \
+  make -j 4 && \
   make install && \
   echo "**** compile irrlicht ****" && \
   mkdir -p /tmp/irrlicht && \
@@ -80,7 +80,7 @@ RUN \
     /tmp/irrlicht --strip-components=1 && \
   cd /tmp/irrlicht && \
   cmake . && \
-  make -j 2 && \
+  make -j 4 && \
   make install && \
   echo "**** compile minetestserver ****" && \
   if [ -z ${MINETEST_RELEASE+x} ]; then \
@@ -113,12 +113,12 @@ RUN \
     -DENABLE_SOUND=0 \
     -DENABLE_SYSTEM_GMP=1 \
     -DRUN_IN_PLACE=0 && \
-  make -j 2 && \
+  make -j 4 && \
   make install && \
   echo "**** copy games to temporary folder ****" && \
   mkdir -p \
     /defaults/games && \
-  cp -pr  /usr/share/minetest/games/* /defaults/games/ && \
+  cp -pr  /tmp/minetest/games/* /defaults/games/ && \
   echo "**** split after 3rd dot if it exists in minetest tag variable ****" && \
   echo "**** so we fetch game version x.x.x etc ****" && \
   if [ $(echo "$MINETEST_RELEASE" | tr -cd '.' | wc -c) = 3 ]; then \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -68,7 +68,7 @@ RUN \
   cd /tmp/spatialindex && \
   cmake . \
     -DCMAKE_INSTALL_PREFIX=/usr && \
-  make -j 2 && \
+  make -j 4 && \
   make install && \
   echo "**** compile irrlicht ****" && \
   mkdir -p /tmp/irrlicht && \
@@ -80,7 +80,7 @@ RUN \
     /tmp/irrlicht --strip-components=1 && \
   cd /tmp/irrlicht && \
   cmake . && \
-  make -j 2 && \
+  make -j 4 && \
   make install && \
   echo "**** compile minetestserver ****" && \
   if [ -z ${MINETEST_RELEASE+x} ]; then \
@@ -113,12 +113,12 @@ RUN \
     -DENABLE_SOUND=0 \
     -DENABLE_SYSTEM_GMP=1 \
     -DRUN_IN_PLACE=0 && \
-  make -j 2 && \
+  make -j 4 && \
   make install && \
   echo "**** copy games to temporary folder ****" && \
   mkdir -p \
     /defaults/games && \
-  cp -pr  /usr/share/minetest/games/* /defaults/games/ && \
+  cp -pr  /tmp/minetest/games/* /defaults/games/ && \
   echo "**** split after 3rd dot if it exists in minetest tag variable ****" && \
   echo "**** so we fetch game version x.x.x etc ****" && \
   if [ $(echo "$MINETEST_RELEASE" | tr -cd '.' | wc -c) = 3 ]; then \

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **09.04.23:** - Build logic changes to copy devtest to default games.
 * **17.03.23:** - Fix CLI_ARGS example in readme.
 * **23.02.23:** - Rebase to Alpine 3.17, migrate to s6v3.
 * **06.08.22:** - Update irrlicht deps.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -53,6 +53,7 @@ app_setup_block: |
   https://hub.docker.com/r/linuxserver/{{ project_name }}/tags
 # changelog
 changelogs:
+  - { date: "09.04.23:", desc: "Build logic changes to copy devtest to default games."}
   - { date: "17.03.23:", desc: "Fix CLI_ARGS example in readme."}
   - { date: "23.02.23:", desc: "Rebase to Alpine 3.17, migrate to s6v3."}
   - { date: "06.08.22:", desc: "Update irrlicht deps."}


### PR DESCRIPTION
The make config no longer installs the devtest game profile by default need to pull it from source. 
I am not really a minetest server admin but seems better to have this building than looping. 