### PR TITLE
Add support for PostgreSQL backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN \
     libjpeg-turbo-dev \
     libogg-dev \
     libpng-dev \
+    libpq-dev \
     openssl-dev \
     libtool \
     libvorbis-dev \
@@ -50,6 +51,7 @@ RUN \
     leveldb \
     libgcc \
     libintl \
+    libpq \
     libstdc++ \
     luajit \
     lua-socket \
@@ -109,6 +111,9 @@ RUN \
     -DENABLE_GETTEXT=0 \
     -DENABLE_LEVELDB=1 \
     -DENABLE_LUAJIT=1 \
+    -DENABLE_POSTGRESQL=1 \
+    -DPostgreSQL_INCLUDE_DIR="/usr/include/postgresql" \
+    -DPostgreSQL_LIBRARY="/usr/lib/libpq.so" \
     -DENABLE_REDIS=1 \
     -DENABLE_SOUND=0 \
     -DENABLE_SYSTEM_GMP=1 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -32,6 +32,7 @@ RUN \
     libjpeg-turbo-dev \
     libogg-dev \
     libpng-dev \
+    libpq-dev \
     openssl-dev \
     libtool \
     libvorbis-dev \
@@ -51,6 +52,7 @@ RUN \
     libgcc \
     libintl \
     libstdc++ \
+    libpq \
     luajit \
     lua-socket \
     sqlite \
@@ -109,6 +111,9 @@ RUN \
     -DENABLE_GETTEXT=0 \
     -DENABLE_LEVELDB=1 \
     -DENABLE_LUAJIT=1 \
+    -DENABLE_POSTGRESQL=1 \
+    -DPostgreSQL_INCLUDE_DIR="/usr/include/postgresql" \
+    -DPostgreSQL_LIBRARY="/usr/lib/libpq.so" \
     -DENABLE_REDIS=1 \
     -DENABLE_SOUND=0 \
     -DENABLE_SYSTEM_GMP=1 \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -49,6 +49,7 @@ app_setup_block: |
   As per [upstream request](https://github.com/minetest/minetest/releases/tag/5.8.0) this image no longer includes [minetest_game](https://github.com/minetest/minetest_game), so if required you will need to either install via ContentDB or download it from their repo and copy to `/config/.minetest/games/minetest`
 # changelog
 changelogs:
+  - {date: "01.13.24:", desc: "Add PostgreSQL backend support to build."}
   - {date: "12.07.23:", desc: "Rebase to Alpine 3.18, remove minetest_game."}
   - {date: "06.07.23:", desc: "Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)"}
   - {date: "09.04.23:", desc: "Build logic changes to copy devtest to default games."}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-minetest/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This PR adds support for the PostgreSQL backend to the minetest server build.

## Benefits of this PR and context:
PostgreSQL is a more performant database backend for minetest servers. The default database backend is sqlite3, which can bottleneck your server under high client load.

To use the PostgreSQL backend, you must modify **world.mt**.  This will be created in the **worlds/world** directory by default when the container is started.

A sample configuration might be as follows:
```
# Commented out defaults
# mod_storage_backend = sqlite3
# auth_backend = sqlite3
# player_backend = sqlite3
# backend = sqlite3
mod_storage_backend = postgresql
auth_backend = postgresql
player_backend = postgresql
backend = postgresql
pgsql_connection =             host=your-db-hostname port=5432 user=postgres password=hunter2 dbname=minetest
pgsql_player_connection =      host=your-db-hostname port=5432 user=postgres password=hunter2 dbname=minetest
pgsql_auth_connection =        host=your-db-hostname port=5432 user=postgres password=hunter2 dbname=minetest
pgsql_mod_storage_connection = host=your-db-hostname port=5432 user=postgres password=hunter2 dbname=minetest
```

In this example, you would be running a PostgreSQL server at "your-db-hostname", with admin user/password postgres/hunter2. The database "minetest" doesn't have to exist, provided that the user "postgres" has sufficient rights to create a database.

## How Has This Been Tested?
Image has been tested on x86_64 Ubuntu 22.04, and PostgreSQL support has been verified both in the build logs, and in the final server binary.

## Source / References:

https://wiki.minetest.net/Database_backends#PostgreSQL


